### PR TITLE
refactor(Time): 상대 시간 기능 개선

### DIFF
--- a/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
+++ b/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
@@ -6,9 +6,16 @@ import com.woowacourse.zzinbros.user.service.UserService;
 import com.woowacourse.zzinbros.user.web.support.SessionInfo;
 import com.woowacourse.zzinbros.user.web.support.UserSession;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.springframework.data.domain.Sort.Direction;
 import static org.springframework.data.domain.Sort.by;
@@ -35,5 +42,11 @@ public class DemoController {
     @GetMapping("/entrance")
     public String enter() {
         return "entrance";
+    }
+
+    @RequestMapping(path = "/time", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ResponseBody
+    public String timeService() {
+        return "\"" + ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\"";
     }
 }

--- a/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
+++ b/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
@@ -14,8 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 
 import static org.springframework.data.domain.Sort.Direction;
 import static org.springframework.data.domain.Sort.by;
@@ -47,6 +46,6 @@ public class DemoController {
     @RequestMapping(path = "/time", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ResponseBody
     public String timeService() {
-        return "\"" + ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) + "\"";
+        return "\"" + OffsetDateTime.now().toString() + "\"";
     }
 }

--- a/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
+++ b/src/main/java/com/woowacourse/zzinbros/demo/DemoController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import static org.springframework.data.domain.Sort.Direction;
 import static org.springframework.data.domain.Sort.by;
@@ -43,9 +43,11 @@ public class DemoController {
         return "entrance";
     }
 
-    @RequestMapping(path = "/time", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @RequestMapping(path = "/datetime", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ResponseBody
-    public String timeService() {
-        return "\"" + OffsetDateTime.now().toString() + "\"";
+    public String datetimeService() {
+        return "{ \"datetime\": \""
+                + Instant.now().toString()
+                + "\" }";
     }
 }

--- a/src/main/resources/static/js/time-update.js
+++ b/src/main/resources/static/js/time-update.js
@@ -1,15 +1,36 @@
-const TIMESTAMP_UPDATE_INTERVAL = 30 * 1000; // 30초마다 글자 업데이트
+const TIMESTAMP_UPDATE_INTERVAL = moment.duration({seconds: 30}); // 30초마다 글자 업데이트
 
 // Moment 라이브러리의 전역 로케일 설정
 // TODO: document.documentElement.lang 사용 - 모든 페이지에 언어 설정 필요
 moment.locale("ko");
 
+let serverTime;
+
+const getServerTime = () => {
+    fetch("/datetime")
+        .then(response => response.json())
+        .then(datetime => { serverTime = moment(datetime.datetime); })
+        .catch(ignored => { serverTime = moment(); }); // fallback
+};
+
+const addIntervalToServerTime = () => {
+    if (!serverTime) getServerTime();
+    else serverTime = moment(serverTime).add(TIMESTAMP_UPDATE_INTERVAL);
+};
+
 const updateTimeStrings = () => {
     const timeStamps = document.getElementsByTagName("time");
     for (let timeStamp of timeStamps) {
-        timeStamp.textContent = moment(timeStamp.dateTime).fromNow();
+        timeStamp.textContent = moment(timeStamp.dateTime).from(serverTime);
     }
 };
 
+const updateTimeStringsInterval = () => {
+    addIntervalToServerTime();
+    updateTimeStrings();
+};
+
+// 페이지 처음 로딩시 실행
+getServerTime();
 updateTimeStrings();
-setInterval(updateTimeStrings, TIMESTAMP_UPDATE_INTERVAL);
+setInterval(updateTimeStringsInterval, TIMESTAMP_UPDATE_INTERVAL.asMilliseconds());

--- a/src/main/resources/static/js/time-update.js
+++ b/src/main/resources/static/js/time-update.js
@@ -1,27 +1,31 @@
-const TIMESTAMP_UPDATE_INTERVAL = moment.duration({seconds: 30}); // 30초마다 글자 업데이트
+const UPDATE_INTERVAL = 10; // 10초마다 글자 업데이트
+const SECOND = "second";
 
-// Moment 라이브러리의 전역 로케일 설정
-// TODO: document.documentElement.lang 사용 - 모든 페이지에 언어 설정 필요
-moment.locale("ko");
+// 가벼운 시간 라이브러리인 Day.js 사용 https://github.com/iamkun/dayjs
+// 전역 한국어 로케일 설정 및 상대 시간 출력 플러그인 적용
+dayjs.locale("ko");
+dayjs.extend(dayjs_plugin_relativeTime);
 
 let serverTime;
 
 const getServerTime = () => {
     fetch("/datetime")
         .then(response => response.json())
-        .then(datetime => { serverTime = moment(datetime.datetime); })
-        .catch(ignored => { serverTime = moment(); }); // fallback
+        .then(datetime => { serverTime = dayjs(datetime.datetime); })
+        .catch(ignored => { serverTime = dayjs(); }); // fallback
 };
 
 const addIntervalToServerTime = () => {
     if (!serverTime) getServerTime();
-    else serverTime = moment(serverTime).add(TIMESTAMP_UPDATE_INTERVAL);
+    else serverTime = dayjs(serverTime).add(UPDATE_INTERVAL, SECOND);
 };
 
 const updateTimeStrings = () => {
     const timeStamps = document.getElementsByTagName("time");
     for (let timeStamp of timeStamps) {
-        timeStamp.textContent = moment(timeStamp.dateTime).from(serverTime);
+        timeStamp.textContent = dayjs(timeStamp.dateTime)
+            .subtract(UPDATE_INTERVAL, SECOND)
+            .from(serverTime);
     }
 };
 
@@ -30,7 +34,4 @@ const updateTimeStringsInterval = () => {
     updateTimeStrings();
 };
 
-// 페이지 처음 로딩시 실행
-getServerTime();
-updateTimeStrings();
-setInterval(updateTimeStringsInterval, TIMESTAMP_UPDATE_INTERVAL.asMilliseconds());
+setInterval(updateTimeStringsInterval, UPDATE_INTERVAL * 1000);

--- a/src/main/resources/templates/common/cdns.html
+++ b/src/main/resources/templates/common/cdns.html
@@ -6,8 +6,12 @@
         integrity="sha256-fTuUgtT7O2rqoImwjrhDgbXTKUwyxxujIMRIK7TbuNU=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/js/bootstrap.bundle.min.js"
         integrity="sha256-fzFFyH01cBVPYzl16KT40wqjhgPtq6FFUB6ckN2+GGw=" crossorigin="anonymous" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"
-        integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.8.16/dayjs.min.js"
+        integrity="sha256-4ZAJq9kaOQU0baQImJ8cE4swV+cAOrx/NL11yOL+VvY=" crossorigin="anonymous" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.8.16/locale/ko.js"
+        integrity="sha256-oZqabx7mLAMIdi+YzMcpis+ypVFvYjwo8Ij70M+o1eA=" crossorigin="anonymous" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.8.16/plugin/relativeTime.js"
+        integrity="sha256-fyF+Tdz+En6oGAS5u/Hs9OpUEJ41VZ1/L78QDMaPfSE=" crossorigin="anonymous" defer></script>
 
 <script src="/js/fetch-api.js" defer></script>
 <script src="/js/logout.js" defer></script>

--- a/src/test/java/com/woowacourse/zzinbros/demo/DemoControllerTest.java
+++ b/src/test/java/com/woowacourse/zzinbros/demo/DemoControllerTest.java
@@ -5,10 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.Duration;
-import java.time.OffsetDateTime;
-import java.util.Objects;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -50,17 +46,12 @@ class DemoControllerTest extends AuthedWebTestClient {
     }
 
     @Test
-    @DisplayName("서버에서 시간 정보를 받아와, 시간 차이가 1초 내인지 확인한다.")
-    void time() {
-        webTestClient.get().uri("/time")
+    @DisplayName("서버에서 시간 정보를 받아온다.")
+    void datetime() {
+        webTestClient.get().uri("/datetime")
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody().consumeWith(response -> {
-                    final String body = new String(Objects.requireNonNull(response.getResponseBody()))
-                            .replaceAll("^.|.$", "");
-                    final OffsetDateTime serverTime = OffsetDateTime.parse(body);
-                    final Duration duration = Duration.between(serverTime, OffsetDateTime.now());
-                    assertThat(duration).isLessThanOrEqualTo(Duration.ofSeconds(1));
-        });
+                .expectBody()
+                .jsonPath("$.datetime").isNotEmpty();
     }
 }

--- a/src/test/java/com/woowacourse/zzinbros/demo/DemoControllerTest.java
+++ b/src/test/java/com/woowacourse/zzinbros/demo/DemoControllerTest.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -43,5 +47,20 @@ class DemoControllerTest extends AuthedWebTestClient {
     @DisplayName("로그인 되지 않았을 때, /entrance로 get요청하면 entrance페이지를 받아온다.")
     void enterFailIfLogIn() throws Exception {
         //TODO : 테스트 작성하여야 함
+    }
+
+    @Test
+    @DisplayName("서버에서 시간 정보를 받아와, 시간 차이가 1초 내인지 확인한다.")
+    void time() {
+        webTestClient.get().uri("/time")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody().consumeWith(response -> {
+                    final String body = new String(Objects.requireNonNull(response.getResponseBody()))
+                            .replaceAll("^.|.$", "");
+                    final OffsetDateTime serverTime = OffsetDateTime.parse(body);
+                    final Duration duration = Duration.between(serverTime, OffsetDateTime.now());
+                    assertThat(duration).isLessThanOrEqualTo(Duration.ofSeconds(1));
+        });
     }
 }


### PR DESCRIPTION
- 서버에서 시간을 제공하는 API를 추가하여, 클라이언트의 시간이 잘못 맞춰진 경우에도 올바르게 시간이 표시될 수 있게끔 하였습니다. 클라이언트에서는 최초 페이지 접속시 1번만 시간을 받아옵니다. 또한 해당 API의 지연시간은 0.01초 미만을 목표로 잡았습니다.
- 클라이언트의 시간 라이브러리를 초경량으로 교체하였습니다. 꼭 필요한 기능만을 불러와서 사용하게끔 바꾸었습니다.
- 때때로 상대 시간이 일시적으로 `몇 초 후`로 표시되는 현상을 수정하였습니다.
- 상대 시간을 업데이트하는 간격을 10초로 조정하였습니다.